### PR TITLE
Modified: processes to show GPU Memory Use in MB but removes sm, enc and dec

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -6,7 +6,7 @@
 #define NVSM_CONF_GCOLOR "gpuColor"
 
 #define NVSMI_CMD_GPU_COUNT "nvidia-smi --query-gpu=count --format=csv"
-#define NVSMI_CMD_PROCESSES "nvidia-smi pmon -c 1"
+#define NVSMI_CMD_PROCESSES "nvidia-smi pmon -c 1 -s m"
 #define NVSMI_CMD_GPU_UTILIZATION "nvidia-smi --query-gpu=utilization.gpu --format=csv"
 #define NVSMI_CMD_MEM_UTILIZATION "nvidia-smi --query-gpu=utilization.memory,memory.total,memory.free,memory.used --format=csv"
 
@@ -14,20 +14,14 @@
 #define NVSMI_GPUIDX 0
 #define NVSMI_PID    1
 #define NVSMI_TYPE   2
-#define NVSMI_SM     3
-#define NVSMI_MEM    4
-#define NVSMI_ENC    5
-#define NVSMI_DEC    6
-#define NVSMI_NAME   7
+#define NVSMI_MEM    3
+#define NVSMI_NAME   4
 
 // nvidia-system-monitor processes columns
 #define NVSM_GPUIDX 2
 #define NVSM_PID    3
 #define NVSM_TYPE   1
-#define NVSM_SM     4
-#define NVSM_MEM    5
-#define NVSM_ENC    6
-#define NVSM_DEC    7
+#define NVSM_MEM    4
 #define NVSM_NAME   0
 
 #define GRAPTH_OFFSET               32

--- a/src/processes.cpp
+++ b/src/processes.cpp
@@ -8,18 +8,14 @@
 #include "utils.h"
 
 ProcessList::ProcessList(const std::string& name, const std::string& type,
-                         const std::string& gpuIdx, const std::string& pid,
-                         const std::string& sm, const std::string& mem,
-                         const std::string& enc, const std::string& dec)
+                const std::string& gpuIdx, const std::string& pid,
+                const std::string& mem)
 {
     this->name = name;
     this->type = type;
     this->gpuIdx = gpuIdx;
     this->pid = pid;
-    this->sm = sm;
     this->mem = mem;
-    this->enc = enc;
-    this->dec = dec;
 }
 
 void ProcessesWorker::work() {
@@ -34,10 +30,11 @@ void ProcessesWorker::work() {
         data = split(lines[i], " ");
         
         processes.emplace_back(
-            data[NVSMI_NAME], data[NVSMI_TYPE],
-            data[NVSMI_GPUIDX], data[NVSMI_PID],
-            data[NVSMI_SM], data[NVSMI_MEM],
-            data[NVSMI_ENC], data[NVSMI_DEC]
+            data[NVSMI_NAME],
+            data[NVSMI_TYPE],
+            data[NVSMI_GPUIDX],
+            data[NVSMI_PID],
+            data[NVSMI_MEM]
         );
     }
     
@@ -61,14 +58,11 @@ ProcessesTableView::ProcessesTableView(QWidget *parent) : QTableView(parent) {
  
     // Column titles
     QStringList horizontalHeader;
-    horizontalHeader.append("Name");
+    horizontalHeader.append("Name of Process"); // Longer header increases column width so the process names are visible
     horizontalHeader.append("Type (C/G)");
     horizontalHeader.append("GPU ID");
     horizontalHeader.append("Process ID");
-    horizontalHeader.append("Compute use");
-    horizontalHeader.append("GPU Memory Use");
-    horizontalHeader.append("Encoding");
-    horizontalHeader.append("Decoding");
+    horizontalHeader.append("GPU Memory Use (MB)");
     
     model->setHorizontalHeaderLabels(horizontalHeader);
     
@@ -134,10 +128,7 @@ void ProcessesTableView::onDataUpdated() {
         _setItem(i, NVSM_TYPE, type);
         _setItem(i, NVSM_GPUIDX, gpuIdx);
         _setItem(i, NVSM_PID, pid);
-        _setItem(i, NVSM_SM, sm);
-        _setItemExt(i, NVSM_MEM, mem, " MB");
-        _setItem(i, NVSM_ENC, enc);
-        _setItem(i, NVSM_DEC, dec);
+        _setItem(i, NVSM_MEM, mem);
     }
     
     int index = worker->processesIndexByPid(selectedPid);

--- a/src/processes.h
+++ b/src/processes.h
@@ -9,12 +9,11 @@
 struct ProcessList {
     std::string name;
     std::string type; // C or G
-    std::string gpuIdx, pid, sm, mem, enc, dec; // integers
+    std::string gpuIdx, pid, mem; // integers
     
     ProcessList(const std::string &name, const std::string &type,
                 const std::string &gpuIdx, const std::string &pid,
-                const std::string &sm, const std::string &mem,
-                const std::string &enc, const std::string &dec);
+                const std::string &mem);
 };
 
 class ProcessesWorker : public Worker {


### PR DESCRIPTION
A possible fix to show GPU memory usage in MB. Requires modifying NVSMI_CMD_PROCESSES to show metrics in MB. This removes the sm, encoder, and decoder information, which are only available in percentage mode. 