### PR TITLE
Show GPU Memory Usage without removing utilization metrics

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -6,7 +6,7 @@
 #define NVSM_CONF_GCOLOR "gpuColor"
 
 #define NVSMI_CMD_GPU_COUNT "nvidia-smi --query-gpu=count --format=csv"
-#define NVSMI_CMD_PROCESSES "nvidia-smi pmon -c 1"
+#define NVSMI_CMD_PROCESSES "nvidia-smi pmon -c 1 -s um"
 #define NVSMI_CMD_GPU_UTILIZATION "nvidia-smi --query-gpu=utilization.gpu --format=csv"
 #define NVSMI_CMD_MEM_UTILIZATION "nvidia-smi --query-gpu=utilization.memory,memory.total,memory.free,memory.used --format=csv"
 
@@ -18,7 +18,8 @@
 #define NVSMI_MEM    4
 #define NVSMI_ENC    5
 #define NVSMI_DEC    6
-#define NVSMI_NAME   7
+#define NVSMI_FBMEM  7
+#define NVSMI_NAME   8
 
 // nvidia-system-monitor processes columns
 #define NVSM_GPUIDX 2
@@ -28,6 +29,7 @@
 #define NVSM_MEM    5
 #define NVSM_ENC    6
 #define NVSM_DEC    7
+#define NVSM_FBMEM  8
 #define NVSM_NAME   0
 
 #define GRAPTH_OFFSET               32

--- a/src/constants.h
+++ b/src/constants.h
@@ -6,7 +6,7 @@
 #define NVSM_CONF_GCOLOR "gpuColor"
 
 #define NVSMI_CMD_GPU_COUNT "nvidia-smi --query-gpu=count --format=csv"
-#define NVSMI_CMD_PROCESSES "nvidia-smi pmon -c 1 -s m"
+#define NVSMI_CMD_PROCESSES "nvidia-smi pmon -c 1"
 #define NVSMI_CMD_GPU_UTILIZATION "nvidia-smi --query-gpu=utilization.gpu --format=csv"
 #define NVSMI_CMD_MEM_UTILIZATION "nvidia-smi --query-gpu=utilization.memory,memory.total,memory.free,memory.used --format=csv"
 
@@ -14,14 +14,20 @@
 #define NVSMI_GPUIDX 0
 #define NVSMI_PID    1
 #define NVSMI_TYPE   2
-#define NVSMI_MEM    3
-#define NVSMI_NAME   4
+#define NVSMI_SM     3
+#define NVSMI_MEM    4
+#define NVSMI_ENC    5
+#define NVSMI_DEC    6
+#define NVSMI_NAME   7
 
 // nvidia-system-monitor processes columns
 #define NVSM_GPUIDX 2
 #define NVSM_PID    3
 #define NVSM_TYPE   1
-#define NVSM_MEM    4
+#define NVSM_SM     4
+#define NVSM_MEM    5
+#define NVSM_ENC    6
+#define NVSM_DEC    7
 #define NVSM_NAME   0
 
 #define GRAPTH_OFFSET               32

--- a/src/processes.cpp
+++ b/src/processes.cpp
@@ -10,7 +10,8 @@
 ProcessList::ProcessList(const std::string& name, const std::string& type,
                          const std::string& gpuIdx, const std::string& pid,
                          const std::string& sm, const std::string& mem,
-                         const std::string& enc, const std::string& dec)
+                         const std::string& enc, const std::string& dec,
+                         const std::string& fbmem)
 {
     this->name = name;
     this->type = type;
@@ -20,6 +21,7 @@ ProcessList::ProcessList(const std::string& name, const std::string& type,
     this->mem = mem;
     this->enc = enc;
     this->dec = dec;
+    this->fbmem = fbmem;
 }
 
 void ProcessesWorker::work() {
@@ -37,7 +39,8 @@ void ProcessesWorker::work() {
             data[NVSMI_NAME], data[NVSMI_TYPE],
             data[NVSMI_GPUIDX], data[NVSMI_PID],
             data[NVSMI_SM], data[NVSMI_MEM],
-            data[NVSMI_ENC], data[NVSMI_DEC]
+            data[NVSMI_ENC], data[NVSMI_DEC],
+            data[NVSMI_FBMEM]
         );
     }
     
@@ -61,14 +64,15 @@ ProcessesTableView::ProcessesTableView(QWidget *parent) : QTableView(parent) {
  
     // Column titles
     QStringList horizontalHeader;
-    horizontalHeader.append("Name");
+    horizontalHeader.append("Name of Process"); // Longer header increases column width so the process names are visible
     horizontalHeader.append("Type (C/G)");
     horizontalHeader.append("GPU ID");
     horizontalHeader.append("Process ID");
-    horizontalHeader.append("Compute use");
-    horizontalHeader.append("GPU Memory Use");
-    horizontalHeader.append("Encoding");
-    horizontalHeader.append("Decoding");
+    horizontalHeader.append("SM Util (%)");
+    horizontalHeader.append("GPU Mem Util (%)");
+    horizontalHeader.append("Encoding (%)");
+    horizontalHeader.append("Decoding (%)");
+    horizontalHeader.append("FB Mem Usage (MB)");
     
     model->setHorizontalHeaderLabels(horizontalHeader);
     
@@ -121,23 +125,26 @@ void ProcessesTableView::killProcess() {
 }
 
 #define _setItemExt(row, column, str, extra) \
-    ((QStandardItemModel*)model())->setItem(row, column, new QStandardItem(QString((worker->processes[i].str + extra).c_str())))
+    qitem = new QStandardItem(QString((worker->processes[i].str + extra).c_str())); \
+    qitem->setTextAlignment(Qt::AlignHCenter); \
+    ((QStandardItemModel*)model())->setItem(row, column, qitem)
 
 #define _setItem(row, column, str) _setItemExt(row, column, str, "")
 
 void ProcessesTableView::onDataUpdated() {
     model()->removeRows(0, model()->rowCount());
     QMutexLocker locker(&worker->mutex);
-    
+    QStandardItem *qitem;
     for (size_t i = 0; i < worker->processes.size(); i++) {
         _setItem(i, NVSM_NAME, name);
         _setItem(i, NVSM_TYPE, type);
         _setItem(i, NVSM_GPUIDX, gpuIdx);
         _setItem(i, NVSM_PID, pid);
         _setItem(i, NVSM_SM, sm);
-        _setItemExt(i, NVSM_MEM, mem, " MB");
+        _setItem(i, NVSM_MEM, mem);
         _setItem(i, NVSM_ENC, enc);
         _setItem(i, NVSM_DEC, dec);
+        _setItem(i, NVSM_FBMEM, fbmem);
     }
     
     int index = worker->processesIndexByPid(selectedPid);

--- a/src/processes.cpp
+++ b/src/processes.cpp
@@ -8,14 +8,18 @@
 #include "utils.h"
 
 ProcessList::ProcessList(const std::string& name, const std::string& type,
-                const std::string& gpuIdx, const std::string& pid,
-                const std::string& mem)
+                         const std::string& gpuIdx, const std::string& pid,
+                         const std::string& sm, const std::string& mem,
+                         const std::string& enc, const std::string& dec)
 {
     this->name = name;
     this->type = type;
     this->gpuIdx = gpuIdx;
     this->pid = pid;
+    this->sm = sm;
     this->mem = mem;
+    this->enc = enc;
+    this->dec = dec;
 }
 
 void ProcessesWorker::work() {
@@ -30,11 +34,10 @@ void ProcessesWorker::work() {
         data = split(lines[i], " ");
         
         processes.emplace_back(
-            data[NVSMI_NAME],
-            data[NVSMI_TYPE],
-            data[NVSMI_GPUIDX],
-            data[NVSMI_PID],
-            data[NVSMI_MEM]
+            data[NVSMI_NAME], data[NVSMI_TYPE],
+            data[NVSMI_GPUIDX], data[NVSMI_PID],
+            data[NVSMI_SM], data[NVSMI_MEM],
+            data[NVSMI_ENC], data[NVSMI_DEC]
         );
     }
     
@@ -58,11 +61,14 @@ ProcessesTableView::ProcessesTableView(QWidget *parent) : QTableView(parent) {
  
     // Column titles
     QStringList horizontalHeader;
-    horizontalHeader.append("Name of Process"); // Longer header increases column width so the process names are visible
+    horizontalHeader.append("Name");
     horizontalHeader.append("Type (C/G)");
     horizontalHeader.append("GPU ID");
     horizontalHeader.append("Process ID");
-    horizontalHeader.append("GPU Memory Use (MB)");
+    horizontalHeader.append("Compute use");
+    horizontalHeader.append("GPU Memory Use");
+    horizontalHeader.append("Encoding");
+    horizontalHeader.append("Decoding");
     
     model->setHorizontalHeaderLabels(horizontalHeader);
     
@@ -128,7 +134,10 @@ void ProcessesTableView::onDataUpdated() {
         _setItem(i, NVSM_TYPE, type);
         _setItem(i, NVSM_GPUIDX, gpuIdx);
         _setItem(i, NVSM_PID, pid);
-        _setItem(i, NVSM_MEM, mem);
+        _setItem(i, NVSM_SM, sm);
+        _setItemExt(i, NVSM_MEM, mem, " MB");
+        _setItem(i, NVSM_ENC, enc);
+        _setItem(i, NVSM_DEC, dec);
     }
     
     int index = worker->processesIndexByPid(selectedPid);

--- a/src/processes.h
+++ b/src/processes.h
@@ -9,11 +9,12 @@
 struct ProcessList {
     std::string name;
     std::string type; // C or G
-    std::string gpuIdx, pid, mem; // integers
+    std::string gpuIdx, pid, sm, mem, enc, dec; // integers
     
     ProcessList(const std::string &name, const std::string &type,
                 const std::string &gpuIdx, const std::string &pid,
-                const std::string &mem);
+                const std::string &sm, const std::string &mem,
+                const std::string &enc, const std::string &dec);
 };
 
 class ProcessesWorker : public Worker {

--- a/src/processes.h
+++ b/src/processes.h
@@ -9,12 +9,13 @@
 struct ProcessList {
     std::string name;
     std::string type; // C or G
-    std::string gpuIdx, pid, sm, mem, enc, dec; // integers
+    std::string gpuIdx, pid, sm, mem, enc, dec, fbmem; // integers
     
     ProcessList(const std::string &name, const std::string &type,
                 const std::string &gpuIdx, const std::string &pid,
                 const std::string &sm, const std::string &mem,
-                const std::string &enc, const std::string &dec);
+                const std::string &enc, const std::string &dec,
+                const std::string &fbmem);
 };
 
 class ProcessesWorker : public Worker {


### PR DESCRIPTION
One of the [previous changes](https://github.com/congard/nvidia-system-monitor-qt/pull/9)  added GPU Frame Buffer memory usage metric but removed the sm, mem, enc, dec utilization metrics. This change keeps the GPU FB memory usage but adds the utilization metrics back as it is useful to track

In addition, added units in the row heads and centered text alignment for text in the tables. 